### PR TITLE
Refine workflow callbacks

### DIFF
--- a/petri.md
+++ b/petri.md
@@ -227,9 +227,13 @@ particular operation inside a nested `parallel_by`.
     {
         "token": {
             "color": 7,
-            "color_group": 2,
-            "parent_color": 0,
-            "parent_color_group": 0
+            "color_group": {
+                "index": 2,
+                "color_begin": 1,
+                "color_end": 14,
+                "parent_color": 0,
+                "parent_color_group_index": 0
+            }
         },
         "response_links": {
             "success": "http://petri/v1/nets/7/places/12/tokens/7",
@@ -252,9 +256,13 @@ e.g. int > 0.
     {
         "token": {
             "color": 0,
-            "color_group": 0,
-            "parent_color": null,
-            "parent_color_group": null
+            "color_group": {
+                "index": 0,
+                "color_begin": 0,
+                "color_end": 1,
+                "parent_color": null,
+                "parent_color_group": null
+            }
         },
         "requested_data": ["split_size"],
         "response_link": "http://petri/v1/nets/7/places/28/tokens/0"

--- a/petri.md
+++ b/petri.md
@@ -14,7 +14,8 @@ Should be an augmented Petri net DSL, allowing specification of:
     - arcs
 - transitions with complex actions
     - notification
-    - split
+    - create color group (requires `color_group_size` on token)
+    - split (requires `color_group_index` on token)
     - barrier
     - join
     - remove data?
@@ -266,4 +267,25 @@ e.g. int > 0.
         },
         "requested_data": ["split_size"],
         "response_link": "http://petri/v1/nets/7/places/28/tokens/0"
+    }
+
+### Color Group Creation Notification
+Sent to notify the consumer application that a color group has been created.
+This notification is optional.
+
+#### Request
+
+    PUT (user-specified-location)
+    Content-Type: application/json
+    Accepts: application/json
+
+    {
+        "color_group": {
+            "index": 0,
+            "color_begin": 0,
+            "color_end": 1,
+            "parent_color": null,
+            "parent_color_group": null
+        },
+        "response_link": "http://petri/v1/nets/7/places/34/tokens/0"
     }

--- a/petri.md
+++ b/petri.md
@@ -281,11 +281,11 @@ This notification is optional.
 
     {
         "color_group": {
-            "index": 0,
-            "color_begin": 0,
-            "color_end": 1,
-            "parent_color": null,
-            "parent_color_group": null
+            "index": 2,
+            "color_begin": 3,
+            "color_end": 14,
+            "parent_color": 0,
+            "parent_color_group": 0
         },
         "response_link": "http://petri/v1/nets/7/places/34/tokens/0"
     }

--- a/workflow.md
+++ b/workflow.md
@@ -493,16 +493,32 @@ Note that this section is contingent on understanding the APIs of the shell
 command and petri services.
 
 ### PUT /v1/callbacks/operations/(operation-id)/create-scope
-Defines a new scope for the operation's inputs and outputs.  This is needed to
-register token colors with nested parallel-by scopes.
+The end point for callbacks from the `create-color-group` Petri action.
+
+Defines a new scope for the operation's inputs and outputs based on the color
+group sent in the body.  This is needed to register token colors with nested
+parallel-by scopes.
+
+### PUT /v1/callbacks/operations/(operation-id)/create-top-level-scope
+An end point for the `notify` Petri action.
+
+Defines the top level scope for a workflow based on the color group information
+of the token that was sent in the body.
 
 ### PUT /v1/callbacks/operations/(operation-id)/begin/(method)
+An end point for the `notify` Petri action.
+
 This callback is used to notify us to begin either `shortcut` or `execute` for
 a particular operation + token color (token color is specified in the body).
 
 ### PUT /v1/callbacks/operations/(operation-id)/data-request?input=foo
+An end point for the `notify` Petri action.
+
 This callback is used to request the size of a parallel-by operation.
 
 ### PUT /v1/callbacks/executions/(execution-id)/(shell-command-type)/(notification-type)
+End points for the various shell command interactions.  These should be
+described individually.
+
 - update operation status
 - create appropriate token in the petri net

--- a/workflow.md
+++ b/workflow.md
@@ -492,13 +492,17 @@ Request:
 Note that this section is contingent on understanding the APIs of the shell
 command and petri services.
 
-### PUT /v1/callbacks/petri/notifications/executions/(execution-id)/(method)
-This callback is used to notify us to begin either `shortcut` or `execute` for
-an operation.
+### PUT /v1/callbacks/operations/(operation-id)/create-scope
+Defines a new scope for the operation's inputs and outputs.  This is needed to
+register token colors with nested parallel-by scopes.
 
-### PUT /v1/callbacks/petri/data-request/executions/(execution-id)?input=foo
+### PUT /v1/callbacks/operations/(operation-id)/begin/(method)
+This callback is used to notify us to begin either `shortcut` or `execute` for
+a particular operation + token color (token color is specified in the body).
+
+### PUT /v1/callbacks/operations/(operation-id)/data-request?input=foo
 This callback is used to request the size of a parallel-by operation.
 
-### PUT /v1/callbacks/(shell-command-type)/(notification-type)?execution_identifier=(exec_id)
+### PUT /v1/callbacks/executions/(execution-id)/(shell-command-type)/(notification-type)
 - update operation status
 - create appropriate token in the petri net

--- a/workflow.md
+++ b/workflow.md
@@ -492,31 +492,36 @@ Request:
 Note that this section is contingent on understanding the APIs of the shell
 command and petri services.
 
-### PUT /v1/callbacks/operations/(operation-id)/create-scope
+### Petri Listeners
+
+#### PUT /v1/callbacks/workflows/(workflow-id)/create-scope-set
 The end point for callbacks from the `create-color-group` Petri action.
 
-Defines a new scope for the operation's inputs and outputs based on the color
-group sent in the body.  This is needed to register token colors with nested
-parallel-by scopes.
+Defines a new layer of scopes in a workflow based on the color group sent in
+the body.  This is needed to associated token colors with nested parallel-by
+scopes.
 
-### PUT /v1/callbacks/operations/(operation-id)/create-top-level-scope
+#### PUT /v1/callbacks/workflows/(workflow-id)/create-scope
 An end point for the `notify` Petri action.
 
 Defines the top level scope for a workflow based on the color group information
 of the token that was sent in the body.
 
-### PUT /v1/callbacks/operations/(operation-id)/begin/(method)
+#### PUT /v1/callbacks/operations/(operation-id)/begin/(method)
 An end point for the `notify` Petri action.
 
 This callback is used to notify us to begin either `shortcut` or `execute` for
-a particular operation + token color (token color is specified in the body).
+a particular operation + scope (token color is specified in the body, which can
+be used to figure out the scope).
 
-### PUT /v1/callbacks/operations/(operation-id)/data-request?input=foo
+#### PUT /v1/callbacks/operations/(operation-id)/data-request?input=foo
 An end point for the `notify` Petri action.
 
 This callback is used to request the size of a parallel-by operation.
 
-### PUT /v1/callbacks/executions/(execution-id)/(shell-command-type)/(notification-type)
+### Shell Command Listeners
+
+#### PUT /v1/callbacks/executions/(execution-id)/(shell-command-type)/(notification-type)
 End points for the various shell command interactions.  These should be
 described individually.
 


### PR DESCRIPTION
Workflow needs to know what colors (color groups really) to associate with what scope layers.

I think this will be a very inefficient way of doing this, because we really only need to be notified for each split.  We might need to implement a special webhook in petri for splits.
